### PR TITLE
feat: improve mobile responsiveness across all sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Contact } from "@/components/sections/Contact";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col overflow-hidden">
+    <main className="flex min-h-screen flex-col overflow-x-hidden">
       <Hero />
       <About />
       <Experience />

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -32,7 +32,7 @@ const bentoItems = [
 
 export function About() {
   return (
-    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-24 px-4 sm:px-12 lg:px-24">
+    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-16 sm:py-24 px-4 sm:px-12 lg:px-24">
       <div className="absolute inset-0 bg-grid-white/[0.02] bg-[size:50px_50px]" />
       
       <div className="z-10 w-full max-w-6xl">
@@ -41,7 +41,7 @@ export function About() {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true, margin: "-100px" }}
           transition={{ duration: 0.6 }}
-          className="mb-16"
+          className="mb-8 sm:mb-16"
         >
           <h2 className="text-4xl sm:text-5xl font-bold tracking-tight mb-6">
             Building robust systems <br className="hidden sm:block" />
@@ -52,7 +52,7 @@ export function About() {
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 auto-rows-[200px]">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6 md:auto-rows-[200px]">
           {bentoItems.map((item, i) => (
             <motion.div
               key={i}
@@ -61,17 +61,17 @@ export function About() {
               viewport={{ once: true, margin: "-50px" }}
               transition={{ duration: 0.5, delay: i * 0.1 }}
               whileHover={{ y: -5, scale: 1.02 }}
-              className={`glass rounded-3xl p-8 flex flex-col justify-between overflow-hidden group relative ${item.className}`}
+              className={`glass rounded-2xl sm:rounded-3xl p-5 sm:p-8 flex flex-col justify-between overflow-hidden group relative ${item.className}`}
             >
               <div className="absolute inset-0 bg-gradient-to-br from-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-              
-              <div className="bg-black/40 rounded-full w-12 h-12 flex items-center justify-center mb-6">
+
+              <div className="bg-black/40 rounded-full w-10 h-10 sm:w-12 sm:h-12 flex items-center justify-center mb-4 sm:mb-6">
                 {item.icon}
               </div>
-              
+
               <div>
-                <h3 className="text-xl font-semibold text-white mb-2">{item.title}</h3>
-                <p className="text-zinc-400 leading-relaxed text-sm sm:text-base">
+                <h3 className="text-base sm:text-xl font-semibold text-white mb-2">{item.title}</h3>
+                <p className="text-zinc-400 leading-relaxed text-sm">
                   {item.description}
                 </p>
               </div>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -19,13 +19,13 @@ export function Contact() {
   };
 
   return (
-    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-24 px-4 sm:px-12 lg:px-24">
+    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-16 sm:py-24 px-4 sm:px-12 lg:px-24">
       {/* Background radial gradient */}
       <div className="absolute inset-0 flex items-center justify-center -z-10">
         <div className="w-[80vw] h-[80vw] sm:w-[50vw] sm:h-[50vw] bg-indigo-500/10 blur-[150px] rounded-full" />
       </div>
 
-      <div className="z-10 w-full max-w-6xl grid grid-cols-1 md:grid-cols-2 gap-16">
+      <div className="z-10 w-full max-w-6xl grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-16">
         <div className="flex flex-col justify-center">
           <motion.div
             initial={{ opacity: 0, x: -50 }}
@@ -33,14 +33,14 @@ export function Contact() {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <h2 className="text-4xl sm:text-6xl font-bold tracking-tighter mb-6">
+            <h2 className="text-3xl sm:text-5xl lg:text-6xl font-bold tracking-tighter mb-6">
               Let's build <br /> something great.
             </h2>
             <p className="text-lg text-zinc-400 mb-10 max-w-md">
               Currently open for new opportunities. Whether you have a question or just want to say hi, I'll try my best to get back to you!
             </p>
 
-            <div className="flex items-center gap-6">
+            <div className="flex flex-wrap items-center gap-3 sm:gap-6">
               <a
                 href="mailto:hello@arjunmenon.dev"
                 className="flex items-center gap-2 text-zinc-400 hover:text-white transition-colors group"
@@ -82,7 +82,7 @@ export function Contact() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, delay: 0.2 }}
         >
-          <div className="glass p-8 sm:p-10 rounded-3xl relative overflow-hidden group">
+          <div className="glass p-5 sm:p-8 lg:p-10 rounded-2xl sm:rounded-3xl relative overflow-hidden group">
             <div className="absolute inset-0 bg-gradient-to-br from-indigo-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
             
             <form onSubmit={handleSubmit} className="relative z-10 flex flex-col gap-6">

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -54,10 +54,11 @@ export function Experience() {
         { scaleY: 1, ease: "none", transformOrigin: "top center" }
       );
 
+      const isMobile = window.innerWidth < 640;
       itemsRef.current.forEach((item, i) => {
         gsap.fromTo(
           item,
-          { opacity: 0, x: i % 2 === 0 ? -50 : 50 },
+          { opacity: 0, x: isMobile ? 0 : i % 2 === 0 ? -50 : 50 },
           {
             opacity: 1,
             x: 0,
@@ -79,10 +80,10 @@ export function Experience() {
   return (
     <section
       ref={containerRef}
-      className="relative flex min-h-screen w-full flex-col items-center py-24 px-4 sm:px-12 lg:px-24"
+      className="relative flex min-h-screen w-full flex-col items-center py-16 sm:py-24 px-4 sm:px-12 lg:px-24 overflow-x-hidden"
     >
       <div className="z-10 w-full max-w-5xl">
-        <h2 className="text-4xl sm:text-5xl font-bold tracking-tight mb-20 text-center">
+        <h2 className="text-4xl sm:text-5xl font-bold tracking-tight mb-10 sm:mb-20 text-center">
           Experience
         </h2>
 
@@ -112,14 +113,14 @@ export function Experience() {
 
                 {/* Content Card */}
                 <div className="w-full sm:w-5/12 pl-12 sm:pl-0">
-                  <div className="glass p-8 rounded-3xl group hover:border-indigo-500/30 transition-colors duration-300">
+                  <div className="glass p-5 sm:p-8 rounded-2xl sm:rounded-3xl group hover:border-indigo-500/30 transition-colors duration-300">
                     <div className="text-sm font-mono text-indigo-400 mb-2">
                       {exp.date}
                     </div>
-                    <h3 className="text-2xl font-semibold text-white mb-1">
+                    <h3 className="text-xl sm:text-2xl font-semibold text-white mb-1">
                       {exp.role}
                     </h3>
-                    <div className="text-lg text-zinc-400 mb-4 font-medium">
+                    <div className="text-base sm:text-lg text-zinc-400 mb-4 font-medium">
                       {exp.company}
                     </div>
                     <p className="text-zinc-500 mb-6 leading-relaxed">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -46,7 +46,7 @@ export function Hero() {
       <div className="z-10 flex flex-col items-center text-center px-4 mix-blend-difference pointer-events-none">
         <h1
           ref={textRef}
-          className="text-6xl sm:text-8xl md:text-9xl font-bold tracking-tighter text-white"
+          className="text-5xl sm:text-8xl md:text-9xl font-bold tracking-tighter text-white"
           style={{ perspective: "1000px" }}
         >
           {name.split("").map((char, i) => (
@@ -62,11 +62,11 @@ export function Hero() {
 
         <p
           ref={subtextRef}
-          className="mt-6 text-xl sm:text-2xl text-zinc-300 max-w-2xl"
+          className="mt-4 sm:mt-6 text-lg sm:text-2xl text-zinc-300 max-w-2xl"
         >
           Full-Stack Software Engineer
           <br className="hidden sm:block" />
-          <span className="text-zinc-500 text-base sm:text-lg">
+          <span className="text-zinc-500 text-sm sm:text-lg block sm:inline mt-1 sm:mt-0">
             Brisbane, AU • C# • Next.js • AWS
           </span>
         </p>

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -131,9 +131,9 @@ function ProjectCard({ project, index }: { project: any; index: number }) {
 
 export function Projects() {
   return (
-    <section className="relative flex min-h-screen w-full flex-col items-center py-24 px-4 sm:px-12 lg:px-24">
+    <section className="relative flex min-h-screen w-full flex-col items-center py-16 sm:py-24 px-4 sm:px-12 lg:px-24">
       <div className="z-10 w-full max-w-6xl">
-        <div className="mb-20 text-center sm:text-left">
+        <div className="mb-10 sm:mb-20 text-center sm:text-left">
           <h2 className="text-4xl sm:text-5xl font-bold tracking-tight mb-4">
             Selected Work
           </h2>
@@ -143,11 +143,11 @@ export function Projects() {
         </div>
 
         <div
-          className="grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-12 perspective-[2000px]"
+          className="grid grid-cols-1 md:grid-cols-2 gap-6 sm:gap-8 lg:gap-12 perspective-[2000px]"
           style={{ perspective: "2000px" }}
         >
           {projects.map((project, i) => (
-            <div key={i} className="h-[400px]">
+            <div key={i} className="min-h-[320px] sm:h-[400px]">
               <ProjectCard project={project} index={i} />
             </div>
           ))}

--- a/src/components/sections/TechStack.tsx
+++ b/src/components/sections/TechStack.tsx
@@ -69,8 +69,8 @@ function IconSphere() {
 
 export function TechStack() {
   return (
-    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-24 px-4 sm:px-12 lg:px-24 overflow-hidden">
-      <div className="z-10 w-full max-w-5xl text-center mb-16">
+    <section className="relative flex min-h-screen w-full flex-col items-center justify-center py-16 sm:py-24 px-4 sm:px-12 lg:px-24 overflow-hidden">
+      <div className="z-10 w-full max-w-5xl text-center mb-8 sm:mb-16">
         <h2 className="text-4xl sm:text-5xl font-bold tracking-tight mb-6">
           Core Technologies
         </h2>
@@ -79,7 +79,7 @@ export function TechStack() {
         </p>
       </div>
 
-      <div className="relative w-full h-[500px] flex items-center justify-center">
+      <div className="relative w-full h-[300px] sm:h-[500px] flex items-center justify-center">
         {/* Background glow */}
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-indigo-500/20 rounded-full blur-[100px]" />
         
@@ -92,9 +92,9 @@ export function TechStack() {
         </div>
 
         {/* Floating tech icons around the canvas */}
-        <div className="absolute inset-0 z-10 pointer-events-none flex flex-wrap justify-center items-center gap-8 px-4 opacity-80 mix-blend-screen">
+        <div className="absolute inset-0 z-10 pointer-events-none flex flex-wrap justify-center items-center gap-4 sm:gap-6 md:gap-8 px-4 opacity-80 mix-blend-screen">
             {icons.map((src, i) => (
-                <img key={i} src={src} alt="tech icon" className="w-12 h-12 md:w-16 md:h-16 object-contain grayscale opacity-50 transition-all duration-500 hover:grayscale-0 hover:opacity-100 pointer-events-auto cursor-pointer hover:scale-110" />
+                <img key={i} src={src} alt="tech icon" className="w-8 h-8 sm:w-12 sm:h-12 md:w-16 md:h-16 object-contain grayscale opacity-50 transition-all duration-500 hover:grayscale-0 hover:opacity-100 pointer-events-auto cursor-pointer hover:scale-110" />
             ))}
         </div>
       </div>


### PR DESCRIPTION
Fixes #2

## Summary
- **Hero**: Smaller base font size (`text-5xl`), tighter spacing, subtitle stacks on mobile
- **About**: Responsive bento grid row heights (auto on mobile, fixed 200px on md+), smaller card padding and radius
- **Experience**: Disabled GSAP x-axis animation on mobile to prevent horizontal overflow, smaller card padding/heading sizes
- **Projects**: Responsive card height (`min-h` on mobile vs fixed height on sm+), reduced grid gaps
- **TechStack**: Responsive canvas height (300px mobile, 500px sm+), smaller icon sizes
- **Contact**: Wrapping social links, responsive grid gap, smaller heading and form padding

Generated with [Claude Code](https://claude.ai/code)